### PR TITLE
fix: Add or Edit product page break on first-time installation

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -56,10 +56,11 @@ class Data extends AbstractHelper
      */
     public function getSecureApiKey(): string
     {
-        return $this->scopeConfig->getValue(
+        $secureApiKey =  $this->scopeConfig->getValue(
             self::XPATH_FIELD_API_KEY,
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE
         );
+        return isset($secureApiKey) ? (string) $secureApiKey : '';
     }
 
     /**


### PR DESCRIPTION
The purpose of this PR is to fix the page break issue on catalog products
on first-time installation. Now, after this PR, the Catalog product add
or edit product, the page does not break on the first time installation. 
