### PR TITLE
fix: save system configuration if module disable

### DIFF
--- a/Plugin/ConfigPlugin.php
+++ b/Plugin/ConfigPlugin.php
@@ -55,7 +55,10 @@ class ConfigPlugin
     ) {
 
         $data = $subject->getData();
-        if (isset($data['groups']['settings']['fields']['imgix_api_key'])) {
+        
+        if ($data['groups']['settings']['fields']['enabled']['value'] == 0) {
+            return $proceed();
+        } elseif (isset($data['groups']['settings']['fields']['imgix_api_key'])) {
             $apiKey = $data['groups']['settings']['fields']['imgix_api_key']['value'];
 
             $apiKeyValidation = $this->helperData->getImgixApiKeyValidation($apiKey);


### PR DESCRIPTION
The purpose of this PR is to fix the page break issue on catalog products
on first-time installation. Now, after this PR, the Catalog product add
or edit product, the page does not break on the first time installation. 

The purpose of this PR is to fix the unable to save system configuration
if the module disabled. Now, after this PR, System configuration is saved
if module is disabled.