### PR TITLE
config: update default param options

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -35,7 +35,7 @@
                     helpful for most users. While these defaults can be changed, we <a href="https://docs.imgix.com/tutorials/responsive-images-srcset-imgix" target="_blank">recommend</a> all
                     users specify a width and/or height.
                     <br/>
-                    <strong>Example: </strong> w=700&h=700&auto=format&fit=crop&crop=entropy]]></comment>
+                    <strong>Example: </strong> w=700&auto=format]]></comment>
                 </field>
                 <field id="small_options" translate="label" type="text" sortOrder="30" showInDefault="1"
                        showInWebsite="1"
@@ -46,7 +46,7 @@
                     helpful for most users. While these defaults can be changed, we <a href="https://docs.imgix.com/tutorials/responsive-images-srcset-imgix" target="_blank">recommend</a> all
                     users specify a width and/or height.
                     <br/>
-                    <strong>Example: </strong> w=500&h=500&auto=format&fit=crop&crop=entropy]]></comment>
+                    <strong>Example: </strong> w=500&auto=format]]></comment>
                 </field>
                 <field id="thumbnail_options" translate="label" type="text" sortOrder="40" showInDefault="1"
                        showInWebsite="1"
@@ -57,7 +57,7 @@
                     helpful for most users. While these defaults can be changed, we <a href="https://docs.imgix.com/tutorials/responsive-images-srcset-imgix" target="_blank">recommend</a> all
                     users specify a width and/or height.
                     <br/>
-                    <strong>Example: </strong> w=100&h=100&auto=format&fit=crop&crop=entropy]]></comment>
+                    <strong>Example: </strong> w=100&auto=format]]></comment>
                 </field>
             </group>
         </section>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -5,9 +5,9 @@
             <settings>
                 <enabled>0</enabled> 
                 <imgix_api_key></imgix_api_key>
-                <default_options><![CDATA[w=700&h=700&auto=format&fit=crop&crop=entropy]]></default_options>
-                <small_options><![CDATA[w=500&h=500&auto=format&fit=crop&crop=entropy]]></small_options>
-                <thumbnail_options><![CDATA[w=100&h=100&auto=format&fit=crop&crop=entropy]]></thumbnail_options>
+                <default_options><![CDATA[w=700&auto=format]]></default_options>
+                <small_options><![CDATA[w=500&auto=format]]></small_options>
+                <thumbnail_options><![CDATA[w=100&auto=format]]></thumbnail_options>
             </settings>
         </imgix>
     </default>


### PR DESCRIPTION
Prior to this commit, we set a height param that would result in
an aspect ratio of 1:1. Now, we specify a width and let the aspect
ratio determine the correct height.

We also specified cropping params, but those have been removed as
well. Typically, you wouldn't want to crop e-commerce images like
that. Now, those params have been removed.