### PR TITLE
Fix: HTML warning gets shown when saving image as template

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -48,6 +48,7 @@
                 <item name="optgroup" xsi:type="string">optgroup</item>
                 <item name="option" xsi:type="string">option</item>
                 <item name="pre" xsi:type="string">pre</item>
+                <item name="a" xsi:type="string">a</item>
             </argument>
             <argument name="allowedAttributes" xsi:type="array">
                 <item name="alt" xsi:type="string">alt</item>
@@ -102,12 +103,22 @@
                 <item name="imgix_auto" xsi:type="string">imgix_auto</item>
                 <item name="imgix_crop" xsi:type="string">imgix_crop</item>
                 <item name="srcset" xsi:type="string">srcset</item>
+                <item name="onclick" xsi:type="string">onclick</item>
+                <item name="download" xsi:type="string">download</item>
+                <item name="media" xsi:type="string">media</item>
+                <item name="ping" xsi:type="string">ping</item>
+                <item name="hreflang" xsi:type="string">hreflang</item>
             </argument>
             <argument name="attributesAllowedByTags" xsi:type="array">
                 <item name="a" xsi:type="array">
                     <item name="tabindex" xsi:type="string">tabindex</item>
                     <item name="target" xsi:type="string">target</item>
                     <item name="rel" xsi:type="string">rel</item>
+                    <item name="onclick" xsi:type="string">onclick</item>
+                    <item name="download" xsi:type="string">download</item>
+                    <item name="media" xsi:type="string">media</item>
+                    <item name="ping" xsi:type="string">ping</item>
+                    <item name="hreflang" xsi:type="string">hreflang</item>
                 </item>
                 <item name="img" xsi:type="array">
                     <item name="src" xsi:type="string">src</item>


### PR DESCRIPTION
The purpose of this PR is to fix the HTML warning that gets shown when saving the image as a template issue.
Now, after this PR, the HTML warning issue is fixed.

Below warning displaying on page saving:

> Temporarily allowed to save HTML value that contains restricted elements. Allowed HTML attributes for tag "a" are: class,width,height,style,alt,title,border,id,data-active-tab,data-appearance,data-autoplay,data-autoplay-speed,data-background-images,data-background-type,data-carousel-mode,data-center-padding,data-content-type,data-element,data-enable-parallax,data-fade,data-grid-size,data-infinite-loop,data-link-type,data-locations,data-overlay-color,data-parallax-speed,data-pb-style,data-same-width,data-show-arrows,data-show-button,data-show-controls,data-show-dots,data-show-overlay,data-slide-name,data-slick-index,data-role,data-product-id,data-price-box,aria-hidden,data-tab-name,data-video-fallback-src,data-video-lazy-load,data-video-loop,data-video-overlay-color,data-video-play-only-visible,data-video-src,href,role,target,imgix_width,imgix_height,imgix_format,imgix_auto,imgix_crop,srcset,tabindex,rel

**Note:** Please check your anchor tag is should be used a single inverted comma. check below example

`<a href="{{store url="about-us"}}">About us</a>`
to
`<a href="{{store url='about-us'}}">About us</a>`

