### PR TITLE
Fix: Admin product thumbnails are displaying origin image instead of  thumbnail images

### DIFF
--- a/Ui/Component/Listing/Column/ConfigurableProducts/Thumbnail.php
+++ b/Ui/Component/Listing/Column/ConfigurableProducts/Thumbnail.php
@@ -4,41 +4,48 @@ namespace Imgix\Magento\Ui\Component\Listing\Column\ConfigurableProducts;
 
 use Magento\Framework\View\Element\UiComponentFactory;
 use Magento\Framework\View\Element\UiComponent\ContextInterface;
+use Imgix\Magento\Helper\Data as ImgixHelper;
+use Magento\Catalog\Helper\Image;
+use Magento\Framework\UrlInterface;
+use Magento\Ui\Component\Listing\Columns\Column;
 
-class Thumbnail extends \Magento\Ui\Component\Listing\Columns\Column
+class Thumbnail extends Column
 {
     public const NAME = 'thumbnail';
 
     public const ALT_FIELD = 'name';
 
     /**
-     * @var \Magento\Catalog\Helper\Image
+     * @var Image
      */
     private $imageHelper;
 
     /**
-     * @var \Magento\Framework\UrlInterface
+     * @var UrlInterface
      */
     private $urlBuilder;
 
     /**
      * @param ContextInterface $context
      * @param UiComponentFactory $uiComponentFactory
-     * @param \Magento\Catalog\Helper\Image $imageHelper
-     * @param \Magento\Framework\UrlInterface $urlBuilder
+     * @param Image $imageHelper
+     * @param ImgixHelper $imgixHelper
+     * @param UrlInterface $urlBuilder
      * @param array $components
      * @param array $data
      */
     public function __construct(
         ContextInterface $context,
         UiComponentFactory $uiComponentFactory,
-        \Magento\Catalog\Helper\Image $imageHelper,
-        \Magento\Framework\UrlInterface $urlBuilder,
+        Image $imageHelper,
+        ImgixHelper $imgixHelper,
+        UrlInterface $urlBuilder,
         array $components = [],
         array $data = []
     ) {
         parent::__construct($context, $uiComponentFactory, $components, $data);
         $this->imageHelper = $imageHelper;
+        $this->imgixHelper = $imgixHelper;
         $this->urlBuilder = $urlBuilder;
     }
 
@@ -56,6 +63,11 @@ class Thumbnail extends \Magento\Ui\Component\Listing\Columns\Column
                 $product = new \Magento\Framework\DataObject($item);
                 $imageUrl = $product->getThumbnail();
                 if (strpos($imageUrl, 'imgix') !== false) {
+                    $thumbnailOptions = null;
+                    $thumbnailOptions = $this->imgixHelper->getThumbnailImageOptions();
+                    if (!empty($thumbnailOptions)) {
+                        $imageUrl = $imageUrl.'?'.$thumbnailOptions;
+                    }
                     $item[$fieldName . '_src'] = $imageUrl;
                     $item[$fieldName . '_alt'] = $this->getAlt($item) ?: $product->getName();
                     $item[$fieldName . '_link'] = $this->urlBuilder->getUrl(

--- a/Ui/Component/Listing/Column/Thumbnail.php
+++ b/Ui/Component/Listing/Column/Thumbnail.php
@@ -7,6 +7,7 @@ use Magento\Framework\View\Element\UiComponentFactory;
 use Magento\Framework\View\Element\UiComponent\ContextInterface;
 use Magento\Ui\Component\Listing\Columns\Column;
 use Magento\Framework\UrlInterface;
+use Imgix\Magento\Helper\Data as ImgixHelper;
 
 class Thumbnail extends Column
 {
@@ -19,6 +20,7 @@ class Thumbnail extends Column
      * @param UiComponentFactory $uiComponentFactory
      * @param Image $imageHelper
      * @param UrlInterface $urlBuilder
+     * @param ImgixHelper $imgixHelper
      * @param array $components
      * @param array $data
      */
@@ -27,11 +29,13 @@ class Thumbnail extends Column
         UiComponentFactory $uiComponentFactory,
         Image $imageHelper,
         UrlInterface $urlBuilder,
+        ImgixHelper $imgixHelper,
         array $components = [],
         array $data = []
     ) {
         parent::__construct($context, $uiComponentFactory, $components, $data);
         $this->imageHelper = $imageHelper;
+        $this->imgixHelper = $imgixHelper;
         $this->urlBuilder = $urlBuilder;
     }
 
@@ -50,6 +54,11 @@ class Thumbnail extends Column
                     $product = new DataObject($item);
                     $imageUrl = $product->getThumbnail();
                     if (strpos($imageUrl, 'imgix') !== false) {
+                        $thumbnailOptions = null;
+                        $thumbnailOptions = $this->imgixHelper->getThumbnailImageOptions();
+                        if (!empty($thumbnailOptions)) {
+                            $imageUrl = $imageUrl.'?'.$thumbnailOptions;
+                        }
                         $item[$fieldName . '_src'] = $imageUrl;
                         $item[$fieldName . '_alt'] = $this->getAlt($item) ?: $product->getName();
                         $item[$fieldName . '_link'] = $this->urlBuilder->getUrl(

--- a/Ui/DataProvider/Product/Form/Modifier/Data/AssociatedProducts.php
+++ b/Ui/DataProvider/Product/Form/Modifier/Data/AssociatedProducts.php
@@ -16,6 +16,7 @@ use Magento\Framework\UrlInterface;
 use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Escaper;
 use Magento\ConfigurableProduct\Ui\DataProvider\Product\Form\Modifier\Data\AssociatedProducts as MageAssociatedProducts;
+use Imgix\Magento\Helper\Data as ImgixHelper;
 
 class AssociatedProducts extends MageAssociatedProducts
 {
@@ -95,6 +96,7 @@ class AssociatedProducts extends MageAssociatedProducts
      * @param JsonHelper $jsonHelper
      * @param ImageHelper $imageHelper
      * @param Escaper|null $escaper
+     * @param ImgixHelper $imgixHelper
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -107,7 +109,8 @@ class AssociatedProducts extends MageAssociatedProducts
         CurrencyInterface $localeCurrency,
         JsonHelper $jsonHelper,
         ImageHelper $imageHelper,
-        Escaper $escaper = null
+        Escaper $escaper = null,
+        ImgixHelper $imgixHelper
     ) {
         $this->locator = $locator;
         $this->urlBuilder = $urlBuilder;
@@ -118,6 +121,7 @@ class AssociatedProducts extends MageAssociatedProducts
         $this->localeCurrency = $localeCurrency;
         $this->jsonHelper = $jsonHelper;
         $this->imageHelper = $imageHelper;
+        $this->imgixHelper = $imgixHelper;
         $this->escaper = $escaper ?: ObjectManager::getInstance()->get(Escaper::class);
         parent::__construct(
             $locator,
@@ -289,6 +293,11 @@ class AssociatedProducts extends MageAssociatedProducts
                     $imageUrl = $product->getThumbnail();
                     if (strpos($imageUrl, 'imgix') !== false) {
                         $thumbnailImageUrl = $imageUrl;
+                        $thumbnailOptions = null;
+                        $thumbnailOptions = $this->imgixHelper->getThumbnailImageOptions();
+                        if (!empty($thumbnailOptions)) {
+                            $thumbnailImageUrl = $thumbnailImageUrl.'?'.$thumbnailOptions;
+                        }
                     } else {
                         $thumbnailImageUrl = $this->imageHelper->init($product, 'product_thumbnail_image')->getUrl();
                     }


### PR DESCRIPTION
The purpose of this PR is to display thumbnail image instead of origin image (full size) on the admin side.
Now, after this PR, the Admin grid will show thumbnail image instead origin image (full size)