### PR TITLE
docs: omit file permissions changes from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,4 @@ php bin/magento setup:static-content:deploy -f
 php bin/magento indexer:reindex
 php bin/magento cache:clean
 php bin/magento cache:flush
-sudo chmod -R 777 var/ pub/ generated/
 ```


### PR DESCRIPTION
The `chmod -R 777` is probably not best for everyone/anyone. Users are in
the best position to decide when/where/how to change the necessary
permissions. We should defer to their best judgement.

Setting permissions with `chmod -R 777` gives all users the ability to read,
write, and execute––this could pose a security risk.

Additionally, we may want to include steps to enter "maintenance mode" after
composer installation (along with a mirrored disabling of "maintenance mode"
in the appropriate spot).