### PR TITLE
perf: reduce number of calls to `sources` endpoint

### DIFF
--- a/Block/Adminhtml/Wysiwyg/Images/Tree.php
+++ b/Block/Adminhtml/Wysiwyg/Images/Tree.php
@@ -62,7 +62,7 @@ class Tree extends \Magento\Backend\Block\Template
         if (isset($sources['errors'])) {
             return $sources = [];
         }
-        return $this->helperData->getEnabledImgixSources();
+        return $sources;
     }
 
     /**


### PR DESCRIPTION
To avoid potentially being rate limited by the API, we should reduce the number of calls to the `sources` endpoint in quick succession.