### PR TITLE
Fix: Product can't add from the admin side in  Magento ECE and Magento EE versions

### DIFF
--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -16,4 +16,9 @@
     </type>
     <preference for="Magento\ConfigurableProduct\Ui\DataProvider\Product\Form\Modifier\Data\AssociatedProducts" 
     			type="Imgix\Magento\Ui\DataProvider\Product\Form\Modifier\Data\AssociatedProducts"/>
+    
+    <preference for="Magento\Catalog\Model\Product\Gallery\CreateHandler" 
+    			type="Imgix\Magento\Model\Product\Gallery\CreateHandler"/>
+    <preference for="Magento\Catalog\Model\Product\Gallery\UpdateHandler"
+               	type="Imgix\Magento\Model\Product\Gallery\UpdateHandler" />
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -2,10 +2,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/e†c/config.xsd">
     <preference for="Magento\Catalog\Block\Adminhtml\Product\Helper\Form\Gallery\Content" 
     			type="Imgix\Magento\Block\Adminhtml\Product\Helper\Form\Gallery\Content"/>
-    <preference for="Magento\Catalog\Model\Product\Gallery\CreateHandler" 
-    			type="Imgix\Magento\Model\Product\Gallery\CreateHandler"/>
-    <preference for="Magento\Catalog\Model\Product\Gallery\UpdateHandler"
-               	type="Imgix\Magento\Model\Product\Gallery\UpdateHandler" />
+    
     <virtualType name="DefaultWYSIWYGValidator" type="Magento\Framework\Validator\HTML\ConfigurableWYSIWYGValidator">
         <arguments>
             <argument name="allowedTags" xsi:type="array">


### PR DESCRIPTION
The purpose of this PR is to fix the varnish test failed issue for the **Magento ECE** and **Magento EE**.
Before this PR, Admin can't add products from the admin side in the **Magento ECE** and **Magento EE** version.
After this admin can add product  in admin side.